### PR TITLE
Fix 'last resort' tokenisation's treatment of trailing characters and add test

### DIFF
--- a/src/python/omorfi/omorfi.py
+++ b/src/python/omorfi/omorfi.py
@@ -441,7 +441,8 @@ class Omorfi:
         pretokens = []
         posttokens = []
         while len(token) > 1 and token[-1] in fin_punct_trailing:
-            posttokens += [{"surf": token[-1], "SpaceBefore": "No"}]
+            posttokens = ([{"surf": token[-1], "SpaceBefore": "No"}]
+                          + posttokens)
             token = token[:-1]
         while len(token) > 1 and token[0] in fin_punct_leading:
             pretokens += [{"surf": token[0], "SpaceAfter": "No"}]
@@ -464,12 +465,19 @@ class Omorfi:
                 retokens.append(retoken)
         return retokens
 
-    def _tokenise(self, line):
+    def fsa_tokenise(self, line):
         """Tokenise with FSA.
         
         @param line  string to tokenise
         """
         return None
+
+    def python_tokenise(self, line):
+        """Tokenise with python's basic string functions.
+
+        @param line  string to tokenise
+        """
+        return self._retokenise(line.split())
 
     def tokenise(self, line):
         """Perform tokenisation with loaded tokeniser if any, or `split()`.
@@ -485,9 +493,9 @@ class Omorfi:
         """
         tokens = None
         if self.tokeniser:
-            tokens = self._tokenise(line)
+            tokens = self.fsa_tokenise(line)
         if not tokens:
-            tokens = self._retokenise(line.split())
+            tokens = self.python_tokenise(line)
         return tokens
 
     def _analyse_str(self, s):

--- a/test/tokenisation.py
+++ b/test/tokenisation.py
@@ -1,0 +1,24 @@
+from argparse import ArgumentParser
+from omorfi.omorfi import Omorfi
+
+WEIRD_TOK = "(OA,...)."
+
+
+def main():
+    a = ArgumentParser()
+    a.add_argument('-f', '--fsa', metavar='FSAFILE', required=True,
+                   help="HFST's optimised lookup binary data for the "
+                        "transducer to be applied")
+    options = a.parse_args()
+    omorfi = Omorfi()
+    omorfi.load_from_dir(options.fsa, analyse=True, accept=True)
+
+    tokens = omorfi.python_tokenise(WEIRD_TOK)
+    # Check tokens are in same order as text
+    start = 0
+    for token in tokens:
+        start = WEIRD_TOK.index(token['surf'], start)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I haven't added the test to the makefile as I couldn't quite figure out how things were structured (I have to relearn autotools from scratch every time I try to deal with it). I noticed there was `tokenisation-test-set.text` but it doesn't seem to be being used anywhere