### PR TITLE
Add gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/gradle/
+/build/
 *.coveragelog
 *.trs
 *.hfst

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,9 @@
+apply plugin: 'java'
+
+sourceSets {
+    main {
+        java {
+            srcDirs = ['src/java']
+        }
+    }
+}


### PR DESCRIPTION
This allows easily pulling in the Java library in, e.g. gradle projects by adding the following the build.gradle:

```
repositories {
    maven { url 'https://jitpack.io' }
}

dependencies {
  implementation 'com.github.flammie:omorfi:develop-SNAPSHOT'
}
```