### PR TITLE
fixed build for Giella

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -482,7 +482,7 @@ generated/omorfi.dix: generated/master.tsv generated/continuations.tsv
 generated/omorfi-giella.lexc: generated/master.tsv generated/continuations.tsv
 	$(PYTHON) $(srcdir)/python/generate-lexcs.py -m generated/master.tsv \
 		$(BLACKLIST_FLAGS) -B TOOSHORTFORCOMPOUND \
-		-i generated/continuations.tsv -o $@ -f=giella
+		-c generated/continuations.tsv -o $@ -f=giella
 
 generated/omorfi-remove-boundaries-giella.regex: generated/timestamp
 	$(PYTHON) $(srcdir)/python/generate-regexes.py \


### PR DESCRIPTION
Running
```
./configure --enable-giella
make
```
would fail with the error:
`generate-lexcs.py: error: the following arguments are required: --continuations/-c`

This fixes the error so that Omorfi can be built with Giella tags too