### PR TITLE
fix memory leak in cpp bindings

### DIFF
--- a/src/cpp/omorfi.cc
+++ b/src/cpp/omorfi.cc
@@ -82,6 +82,7 @@ namespace omorfi {
                 }
                 anals.push_back(a);
             }
+            delete results;
             return anals;
         } else {
             // XXX: error


### PR DESCRIPTION
The bindings did not deallocate the result object. This added up to gigabytes in my program that spams omorfi to brute force letter substitutions that lead to finnish words.