### PR TITLE
fix invalid Python import paths

### DIFF
--- a/src/python/omorfi/entryguessing/gradation.py
+++ b/src/python/omorfi/entryguessing/gradation.py
@@ -17,8 +17,8 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .omorfi.error_logging import fail_guess_because
-from .omorfi.string_mangling import replace_rightmost, replace_rightmosts
+from omorfi.error_logging import fail_guess_because
+from omorfi.string_manglers import replace_rightmost, replace_rightmosts
 
 
 def gradation_make_morphophonemes(wordmap):

--- a/src/python/omorfi/entryguessing/guess_new_class.py
+++ b/src/python/omorfi/entryguessing/guess_new_class.py
@@ -17,8 +17,8 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .error_logging import fail_guess_because
-from .string_manglers import three_syllable
+from omorfi.error_logging import fail_guess_because
+from omorfi.string_manglers import three_syllable
 
 
 def guess_new_class(wordmap):

--- a/src/python/omorfi/entryguessing/plurale_tantum.py
+++ b/src/python/omorfi/entryguessing/plurale_tantum.py
@@ -17,8 +17,8 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .error_logging import fail_guess_because
-from .omorfi.string_manglers import replace_rightmost, replace_rightmosts
+from omorfi.error_logging import fail_guess_because
+from omorfi.string_manglers import replace_rightmost, replace_rightmosts
 
 
 def plurale_tantum_get_singular_stem(wordmap):

--- a/src/python/omorfi/formats/experimental_xml_formatter.py
+++ b/src/python/omorfi/formats/experimental_xml_formatter.py
@@ -19,9 +19,9 @@
 
 from xml.sax.saxutils import escape as xml_escape
 
-from ftb3_formatter import Ftb3Formatter
+from .ftb3_formatter import Ftb3Formatter
 
-from .settings import version_id_easter_egg
+from omorfi.settings import version_id_easter_egg
 
 
 def make_xmlid(s):

--- a/src/python/omorfi/formats/lexc_formatter.py
+++ b/src/python/omorfi/formats/lexc_formatter.py
@@ -19,8 +19,8 @@
 
 # functions for formatting the database data to lexc
 
-from .settings import deriv_boundary, morph_boundary, newword_boundary, optional_hyphen, stub_boundary, word_boundary
-from .string_manglers import lexc_escape
+from omorfi.settings import deriv_boundary, morph_boundary, newword_boundary, optional_hyphen, stub_boundary, word_boundary
+from omorfi.string_manglers import lexc_escape
 
 
 def format_copyright_lexc():


### PR DESCRIPTION
This change fixes the tests in `src/python` failing (ran with `python3 setup.py test`) with errors such as:

```
======================================================================
ERROR: plurale_tantum (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: plurale_tantum
Traceback (most recent call last):
  File "/nix/store/1r6n7v2wam7gkr18gxccpg7p5ywgw551-python3-3.10.12/lib/python3.10/unittest/loader.py", line 154, in loadTestsFromName
    module = __import__(module_name)
  File "/home/jussi/ohj/nix/omorfi/omorfi/omorfi/src/python/omorfi/entryguessing/plurale_tantum.py", line 20, in <module>
    from .error_logging import fail_guess_because
ModuleNotFoundError: No module named 'omorfi.entryguessing.error_logging'
```

Tested with Python 3.10.12