### PR TITLE
Python API: Fix loading HFST file for Generator in Omorfi class

### DIFF
--- a/src/python/omorfi/omorfi.py
+++ b/src/python/omorfi/omorfi.py
@@ -154,7 +154,7 @@ class Omorfi:
         Args:
             f: containing single hfst automaton binary.
         """
-        self.generator = Generator(f)
+        self.generator.load_generator(f)
         self.can_generate = True
 
     def load_acceptor(self, f):


### PR DESCRIPTION
`Generator.__init__()` does not take the HFST file name as an argument. Fix `Omorfi.load_generator()` to use `Generator.load_generator()` instead.